### PR TITLE
Add download progress bar

### DIFF
--- a/sndata/bsnip/_stahl20.py
+++ b/sndata/bsnip/_stahl20.py
@@ -130,7 +130,7 @@ class Stahl20(SpectroscopicRelease):
 
         utils.download_file(
             url=self._meta_table_url,
-            path=self._meta_table_path,
+            destination=self._meta_table_path,
             force=force,
             timeout=timeout
         )

--- a/sndata/csp/_dr3.py
+++ b/sndata/csp/_dr3.py
@@ -249,7 +249,7 @@ class DR3(PhotometricRelease, DefaultParser):
         for file_name in self._filter_file_names:
             utils.download_file(
                 url=self._filter_url + file_name,
-                path=self._filter_dir / file_name,
+                destination=self._filter_dir / file_name,
                 force=force,
                 timeout=timeout
             )

--- a/sndata/essence/_narayan16.py
+++ b/sndata/essence/_narayan16.py
@@ -156,7 +156,7 @@ class Narayan16(PhotometricRelease, DefaultParser):
         for filter_file, filter_url in zip(self._filter_file_names, self._filter_urls):
             utils.download_file(
                 url=filter_url,
-                path=self._filter_dir / filter_file,
+                destination=self._filter_dir / filter_file,
                 force=force,
                 timeout=timeout
             )

--- a/sndata/jla/_betoule14.py
+++ b/sndata/jla/_betoule14.py
@@ -300,7 +300,7 @@ class Betoule14(PhotometricRelease):
 
         utils.download_file(
             url=self._filter_url,
-            path=self._filter_path,
+            destination=self._filter_path,
             force=force,
             timeout=timeout
         )

--- a/sndata/sdss/_sako18.py
+++ b/sndata/sdss/_sako18.py
@@ -271,7 +271,7 @@ class Sako18(PhotometricRelease, DefaultParser):
         for file_name in self._table_names:
             utils.download_file(
                 url=self._base_url + file_name,
-                path=self._table_dir / file_name,
+                destination=self._table_dir / file_name,
                 force=force,
                 timeout=timeout
             )
@@ -279,7 +279,7 @@ class Sako18(PhotometricRelease, DefaultParser):
         for file_name in self._filter_file_names:
             utils.download_file(
                 url=self._filter_url + file_name,
-                path=self._filter_dir / file_name,
+                destination=self._filter_dir / file_name,
                 force=force,
                 timeout=timeout
             )

--- a/sndata/sdss/_sako18spec.py
+++ b/sndata/sdss/_sako18spec.py
@@ -184,7 +184,7 @@ class Sako18Spec(SpectroscopicRelease):
         for file_name in self._table_names:
             utils.download_file(
                 url=self._base_url + file_name,
-                path=self._table_dir / file_name,
+                destination=self._table_dir / file_name,
                 force=force,
                 timeout=timeout
             )

--- a/sndata/sweetspot/_dr1.py
+++ b/sndata/sweetspot/_dr1.py
@@ -192,7 +192,7 @@ class DR1(PhotometricRelease, DefaultParser):
 
         utils.download_file(
             url=self._target_info_url,
-            path=self._target_info_path,
+            destination=self._target_info_path,
             force=force,
             timeout=timeout
         )
@@ -202,7 +202,7 @@ class DR1(PhotometricRelease, DefaultParser):
 
             utils.download_file(
                 url=file_url,
-                path=self._photometry_dir / file_name,
+                destination=self._photometry_dir / file_name,
                 force=force,
                 timeout=timeout,
                 verbose=False


### PR DESCRIPTION
Uses `tqdm` to add a progress bar to `stdout` when downloading files. The progress bar can be disabled if `verbose` is set to False.