### PR TITLE
Adds test to ensure no duplicate aliases in photometric column names

### DIFF
--- a/sndata/loss/_ganeshalingam13.py
+++ b/sndata/loss/_ganeshalingam13.py
@@ -209,8 +209,8 @@ class Ganeshalingam13(PhotometricRelease, DefaultParser):
             object_data['zp'] = zp
             object_data['flux'] = 10 ** ((object_data['Mag'] - object_data['zp']) / -2.5)
             object_data['fluxerr'] = (np.log(10) / -2.5) * object_data['flux'] * object_data['Mag err']
-            object_data['zpsys'] = 'Landolt'
-            object_data.remove_columns(['Mag', 'Mag err'])
+            object_data['zpsys'] = 'AB'
+            object_data.remove_columns(['SN', 'MJD', 'Filter', 'Mag', 'Mag err'])
 
         meta = load_meta()
         obj_meta = meta[meta['obj_id'] == obj_id][0]

--- a/tests/data_parsing_template_tests.py
+++ b/tests/data_parsing_template_tests.py
@@ -128,7 +128,7 @@ class SpectroscopicDataParsing:
 
             self.assertTrue(table, err_msg.format(table))
 
-    def test_column_names(self):
+    def test_standard_column_names(self):
         """Test columns required by sncosmo are included in formatted tables
 
         Columns checked to exist include:
@@ -153,7 +153,8 @@ class PhotometricDataParsing(SpectroscopicDataParsing):
         actual_zp = self.test_class.zero_point
         self.assertSequenceEqual(actual_zp, returned_zp)
 
-    def test_column_names(self):
+    # Overwrites parent class method
+    def test_standard_column_names(self):
         """Test columns required by sncosmo are included in formatted tables
 
         Columns checked to exist include:
@@ -166,6 +167,16 @@ class PhotometricDataParsing(SpectroscopicDataParsing):
         expected_cols = ('time', 'band', 'flux', 'fluxerr', 'zp', 'zpsys')
         for column in expected_cols:
             self.assertIn(column, test_data.colnames)
+
+    def test_no_duplicate_aliases(self):
+
+        test_id = self.test_class.get_available_ids()[0]
+        test_data = self.test_class.get_data_for_id(test_id, format_table=True)
+
+        sncosmo.utils.alias_map(
+            test_data.colnames,
+            sncosmo.photdata.PHOTDATA_ALIASES,
+            required=sncosmo.photdata.PHOTDATA_REQUIRED_ALIASES)
 
     def test_sncosmo_registered_band_names(self):
         """Test registered bands do have the correct name"""

--- a/tests/data_parsing_template_tests.py
+++ b/tests/data_parsing_template_tests.py
@@ -169,6 +169,7 @@ class PhotometricDataParsing(SpectroscopicDataParsing):
             self.assertIn(column, test_data.colnames)
 
     def test_no_duplicate_aliases(self):
+        """Test column names do not have duplicate sncosmo aliases"""
 
         test_id = self.test_class.get_available_ids()[0]
         test_data = self.test_class.get_data_for_id(test_id, format_table=True)

--- a/tests/test_snls.py
+++ b/tests/test_snls.py
@@ -23,7 +23,7 @@ class Balland09Parsing(TestCase, SpectroscopicDataParsing):
     def test_jd_time_format(self):
         pass
 
-    def test_column_names(self):
+    def test_standard_column_names(self):
         """Test columns required by sncosmo are included in formatted tables
 
         Columns checked to exist include:


### PR DESCRIPTION
Ensures photometric data tables do not have duplicate aliases (e.g., both a `filter` and `band` column). Relies on the `sncosmo.utils.alias_map` functionality from `sncosmo`. Passing this test required removing the `MJD` and `filter` columns from `Ganeshalingam13` data tables.