### PR TITLE
Fix Issues/61: Ignore warnings when parsing data tables

### DIFF
--- a/docs/source/change_log.rst
+++ b/docs/source/change_log.rst
@@ -4,10 +4,17 @@ Change Log
 This page documents any API changes between different versions of the
 ``sndata`` package.
 
+Development
+-----------
+
+- Adds data from the second data release of the BLick Observatory Supernova Search (``sndata.loss.Stahl19``).
+- Adds data from the second data release of the Berkely Supernova Ia Program (``sndata.bsnip.Stahl20``).
+- Ignores warnings issued when reading in data files.
+
 V 1.2.0
 -------
 
-- Adds data from the first data release of the BLick Observatory Supernova Search (``sndata.loss.Ganeshalingam13``)
+- Adds data from the first data release of the BLick Observatory Supernova Search (``sndata.loss.Ganeshalingam13``).
 - The ``format`` argument is added to the ``utils.convert_to_jd`` function.
 - Support is added to ``utils.convert_to_jd`` for converting UT times to JD.
 

--- a/sndata/base_classes.py
+++ b/sndata/base_classes.py
@@ -8,7 +8,9 @@ for a new survey / data release, see the :ref:`CustomClasses` section of the
 docs.
 """
 
+import functools
 import shutil
+import warnings
 from typing import List
 from typing import Union
 
@@ -21,6 +23,18 @@ from .exceptions import InvalidObjId, InvalidTableId
 
 # Define short hand type for Ids of Vizier Tables
 VizierTableId = Union[int, str]
+
+
+def ignore_warnings_wrapper(func: callable) -> callable:
+    """Ignores warnings issued by the wrapped function call"""
+
+    @functools.wraps(func)
+    def inner(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            return func(*args, **kwargs)
+
+    return inner
 
 
 class DefaultParser:
@@ -113,6 +127,7 @@ class SpectroscopicRelease:
         return self._get_available_tables()
 
     @utils.lru_copy_cache(maxsize=None)
+    @ignore_warnings_wrapper
     def load_table(self, table_id: VizierTableId) -> Table:
         """Return a Vizier table published by this data release
 
@@ -136,6 +151,7 @@ class SpectroscopicRelease:
         utils.require_data_path(self._data_dir)
         return self._get_available_ids()
 
+    @ignore_warnings_wrapper
     def get_data_for_id(self, obj_id: str, format_table: bool = True) -> Table:
         """Returns data for a given object ID
 


### PR DESCRIPTION
This PR addresses Issue #61 by introducing the `utils.ignore_warnings_wrapper` wrapper. The wrapper ignores any warnings issued by the wrapped function call and is used to ignore warnings when parsing data files. 

The new logic is implemented at the level of the base classes (`sndata.base_classes.SpectroscopicRelease`) and thus will be universally applied to all data releases (i.e., child classes)